### PR TITLE
Ew2d qupdate

### DIFF
--- a/src/USER-CONP/compute_conp_matrix.cpp
+++ b/src/USER-CONP/compute_conp_matrix.cpp
@@ -87,10 +87,6 @@ ComputeConpMatrix::ComputeConpMatrix(LAMMPS *lmp, int narg, char **arg)
 
   g_ewald = 0.0;
 
-  // get jgroup; igroup defined in parent class
-
-  // TODO recalculate coulomb matrix every recalc_every
-
   // TODO infer from pair_style!
   eta = utils::numeric(FLERR, arg[3], false, lmp);
 
@@ -287,7 +283,6 @@ void ComputeConpMatrix::compute_array() {
 /* ---------------------------------------------------------------------- */
 
 void ComputeConpMatrix::invert() {
-  // TODO use vectors for ipiv and work?
   if (comm->me == 0) utils::logmesg(lmp, "CONP inverting matrix\n");
   int m = ngroup, n = ngroup, lda = ngroup;
   int *ipiv = new int[ngroup + 1];
@@ -486,12 +481,9 @@ void ComputeConpMatrix::matrix_assignment() {
   }
 
   memory->create(itaglist, ngroup, "coul/matrix:itaglist");
-
   MPI_Allgatherv(itaglist_local, igroupnum_local, MPI_LMP_TAGINT, itaglist,
                  igroupnum_list, idispls, MPI_LMP_TAGINT, world);
-
-  // sort individual group taglists, first igroup than jgroup
-
+  // must be sorted for compatibility with fix_charge_update
   std::sort(itaglist, itaglist + ngroup);
 
   // if local+ghost matrix assignment already created, recreate
@@ -507,13 +499,11 @@ void ComputeConpMatrix::matrix_assignment() {
   if (nbytes) memset(mpos, -1, nbytes);
 
   // store which tag represents value in matrix
-
   for (bigint i = 0; i < ngroup; i++) mat2tag[i] = itaglist[i];
 
   // create global matrix indices for local+ghost atoms
-
   for (bigint ii = 0; ii < ngroup; ii++)
-    for (int i = 0; i < nlocal; i++)
+    for (int i = 0; i < nlocal; i++) // TODO should this be nmax?
       if (mat2tag[ii] == tag[i]) mpos[i] = ii;
 
   memory->destroy(igroupnum_list);

--- a/src/USER-CONP/compute_conp_matrix.cpp
+++ b/src/USER-CONP/compute_conp_matrix.cpp
@@ -47,22 +47,12 @@ using namespace MathConst;
 #define A4 -1.453152027
 #define A5 1.061405429
 
-extern "C" {
-void dgetrf_(const int *M, const int *N, double *A, const int *lda, int *ipiv,
-             int *info);
-void dgetri_(const int *N, double *A, const int *lda, const int *ipiv,
-             double *work, const int *lwork, int *info);
-}
 enum { OFF, INTER, INTRA };
 
 /* ---------------------------------------------------------------------- */
 
 ComputeConpMatrix::ComputeConpMatrix(LAMMPS *lmp, int narg, char **arg)
-    : Compute(lmp, narg, arg),
-      gradQ_V(nullptr),
-      mpos(nullptr),
-      fp(nullptr),
-      fp_inv(nullptr) {
+    : Compute(lmp, narg, arg), mpos(nullptr), fp(nullptr), fp_inv(nullptr) {
   if (narg < 4) error->all(FLERR, "Illegal compute coul/matrix command");
 
   array_flag = 1;
@@ -73,7 +63,7 @@ ComputeConpMatrix::ComputeConpMatrix(LAMMPS *lmp, int narg, char **arg)
 
   fp = nullptr;
   fp_inv = nullptr;
-  gradQ_V = nullptr;
+  array = nullptr;
   mpos = nullptr;
 
   pairflag = 1;
@@ -264,55 +254,19 @@ void ComputeConpMatrix::compute_array() {
   // setting all entries of coulomb matrix to zero
   size_t nbytes = sizeof(double) * ngroup;
   if (nbytes)
-    for (int i = 0; i < ngroup; i++) memset(&gradQ_V[i][0], 0, nbytes);
+    for (int i = 0; i < ngroup; i++) memset(&array[i][0], 0, nbytes);
 
   if (pairflag) pair_contribution();
   if (selfflag) self_contribution();
-  if (kspaceflag) kspace->compute_matrix(mpos, gradQ_V);
-  if (boundaryflag) kspace->compute_matrix_corr(mpos, gradQ_V);
+  if (kspaceflag) kspace->compute_matrix(mpos, array);
+  if (boundaryflag) kspace->compute_matrix_corr(mpos, array);
 
   // reduce coulomb matrix with contributions from all procs
   // all procs need to know full matrix for matrix inversion
   for (int i = 0; i < ngroup; i++) {
-    MPI_Allreduce(MPI_IN_PLACE, &gradQ_V[i][0], ngroup, MPI_DOUBLE, MPI_SUM,
+    MPI_Allreduce(MPI_IN_PLACE, &array[i][0], ngroup, MPI_DOUBLE, MPI_SUM,
                   world);
   }
-  invert();
-}
-
-/* ---------------------------------------------------------------------- */
-
-void ComputeConpMatrix::invert() {
-  if (comm->me == 0) utils::logmesg(lmp, "CONP inverting matrix\n");
-  int m = ngroup, n = ngroup, lda = ngroup;
-  int *ipiv = new int[ngroup + 1];
-  int info_rf, info_ri;
-  int lwork = ngroup * ngroup;
-  double *work = new double[lwork];
-  double *gradQ_V_inv = new double[ngroup * ngroup];
-
-  for (int i = 0; i < ngroup; i++) {
-    for (int j = 0; j < ngroup; j++) {
-      int idx = i * ngroup + j;
-      gradQ_V_inv[idx] = gradQ_V[i][j];
-    }
-  }
-
-  dgetrf_(&m, &n, gradQ_V_inv, &lda, ipiv, &info_rf);
-  dgetri_(&n, gradQ_V_inv, &lda, ipiv, work, &lwork, &info_ri);
-  delete[] ipiv;
-  ipiv = NULL;
-  delete[] work;
-  work = NULL;
-  if (info_rf != 0 || info_ri != 0)
-    error->all(FLERR, "CONP matrix inversion failed!");
-  for (int i = 0; i < ngroup; i++) {
-    for (int j = 0; j < ngroup; j++) {
-      int idx = i * ngroup + j;
-      array[i][j] = gradQ_V_inv[idx];
-    }
-  }
-  delete[] gradQ_V_inv;
 }
 
 /* ---------------------------------------------------------------------- */
@@ -411,8 +365,8 @@ void ComputeConpMatrix::pair_contribution() {
         // newton on or off?
 
         if (!(newton_pair || j < nlocal)) aij *= 0.5;
-        gradQ_V[mpos[i]][jpos] += aij;
-        gradQ_V[jpos][mpos[i]] += aij;
+        array[mpos[i]][jpos] += aij;
+        array[jpos][mpos[i]] += aij;
       }
     }
   }
@@ -430,7 +384,7 @@ void ComputeConpMatrix::self_contribution() {
   // TODO infer eta from pair_coeffs
   for (int i = 0; i < nlocal; i++)
     if (mask[i] & groupbit) {
-      gradQ_V[mpos[i]][mpos[i]] += preta * eta - selfint;
+      array[mpos[i]][mpos[i]] += preta * eta - selfint;
     }
 }
 
@@ -503,7 +457,7 @@ void ComputeConpMatrix::matrix_assignment() {
 
   // create global matrix indices for local+ghost atoms
   for (bigint ii = 0; ii < ngroup; ii++)
-    for (int i = 0; i < nlocal; i++) // TODO should this be nmax?
+    for (int i = 0; i < nlocal; i++)  // TODO should this be nmax?
       if (mat2tag[ii] == tag[i]) mpos[i] = ii;
 
   memory->destroy(igroupnum_list);
@@ -516,23 +470,15 @@ void ComputeConpMatrix::matrix_assignment() {
 
 void ComputeConpMatrix::allocate() {
   memory->create(mat2tag, ngroup, "coul/matrix:mat2tag");
-  gradQ_V = new double *[ngroup];
   array = new double *[ngroup];
-  for (bigint i = 0; i < ngroup; i++) {
-    gradQ_V[i] = new double[ngroup];
-    array[i] = new double[ngroup];
-  }
+  for (bigint i = 0; i < ngroup; i++) array[i] = new double[ngroup];
 }
 
 /* ---------------------------------------------------------------------- */
 
 void ComputeConpMatrix::deallocate() {
   memory->destroy(mat2tag);
-  for (bigint i = 0; i < ngroup; i++) {
-    delete[] gradQ_V[i];
-    delete[] array[i];
-  }
-  delete[] gradQ_V;
+  for (bigint i = 0; i < ngroup; i++) delete[] array[i];
   delete[] array;
 }
 

--- a/src/USER-CONP/compute_conp_matrix.cpp
+++ b/src/USER-CONP/compute_conp_matrix.cpp
@@ -251,10 +251,6 @@ void ComputeConpMatrix::setup() {
   // TODO could be useful to assign homogenously all atoms in both groups to
   // all procs for calculating matrix to distribute evenly the workload
 
-  // TODO would be nicer to have a local matrix and gather it later
-  // to reduce a little bit the memory consumption ... However, for
-  // this wo work I think the atom ids must be from 1,...,N and consecutive
-
   allocate();
 
   // assign atom tags to matrix locations and vice versa
@@ -272,17 +268,8 @@ void ComputeConpMatrix::setup() {
 
   compute_array();
 
-  // reduce coulomb matrix with contributions from all procs
-  // all procs need to know full matrix for matrix inversion
-
-  for (int i = 0; i < ngroup; i++)
-    MPI_Allreduce(MPI_IN_PLACE, &gradQ_V[i][0], ngroup, MPI_DOUBLE, MPI_SUM,
-                  world);
-
-  invert();
-
   if (fp && comm->me == 0) write_matrix(fp, gradQ_V);
-  if (fp_inv && comm->me == 0) write_matrix(fp_inv, array); 
+  if (fp_inv && comm->me == 0) write_matrix(fp_inv, array);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -296,6 +283,14 @@ void ComputeConpMatrix::compute_array() {
   if (selfflag) self_contribution();
   if (kspaceflag) kspace->compute_matrix(mpos, gradQ_V);
   if (boundaryflag) kspace->compute_matrix_corr(mpos, gradQ_V);
+
+  // reduce coulomb matrix with contributions from all procs
+  // all procs need to know full matrix for matrix inversion
+  for (int i = 0; i < ngroup; i++) {
+    MPI_Allreduce(MPI_IN_PLACE, &gradQ_V[i][0], ngroup, MPI_DOUBLE, MPI_SUM,
+                  world);
+  }
+  invert();
 }
 
 /* ---------------------------------------------------------------------- */
@@ -331,7 +326,7 @@ void ComputeConpMatrix::invert() {
       array[i][j] = gradQ_V_inv[idx];
     }
   }
-  delete [] gradQ_V_inv;
+  delete[] gradQ_V_inv;
 }
 
 /* ---------------------------------------------------------------------- */

--- a/src/USER-CONP/compute_conp_matrix.cpp
+++ b/src/USER-CONP/compute_conp_matrix.cpp
@@ -457,7 +457,7 @@ void ComputeConpMatrix::matrix_assignment() {
 
   // create global matrix indices for local+ghost atoms
   for (bigint ii = 0; ii < ngroup; ii++)
-    for (int i = 0; i < nlocal; i++)  // TODO should this be nmax?
+    for (int i = 0; i < nlocal; i++)  
       if (mat2tag[ii] == tag[i]) mpos[i] = ii;
 
   memory->destroy(igroupnum_list);

--- a/src/USER-CONP/compute_conp_matrix.cpp
+++ b/src/USER-CONP/compute_conp_matrix.cpp
@@ -256,20 +256,9 @@ void ComputeConpMatrix::setup() {
   // assign atom tags to matrix locations and vice versa
 
   matrix_assignment();
-
-  // setting all entries of coulomb matrix to zero
-
-  size_t nbytes = sizeof(double) * ngroup;
-
-  if (nbytes)
-    for (int i = 0; i < ngroup; i++) memset(&gradQ_V[i][0], 0, nbytes);
-
   // initial calculation of coulomb matrix at setup of simulation
 
   compute_array();
-
-  if (fp && comm->me == 0) write_matrix(fp, gradQ_V);
-  if (fp_inv && comm->me == 0) write_matrix(fp_inv, array);
 }
 
 /* ---------------------------------------------------------------------- */
@@ -279,6 +268,11 @@ void ComputeConpMatrix::init_list(int /*id*/, NeighList *ptr) { list = ptr; }
 /* ---------------------------------------------------------------------- */
 
 void ComputeConpMatrix::compute_array() {
+  // setting all entries of coulomb matrix to zero
+  size_t nbytes = sizeof(double) * ngroup;
+  if (nbytes)
+    for (int i = 0; i < ngroup; i++) memset(&gradQ_V[i][0], 0, nbytes);
+
   if (pairflag) pair_contribution();
   if (selfflag) self_contribution();
   if (kspaceflag) kspace->compute_matrix(mpos, gradQ_V);
@@ -556,33 +550,3 @@ void ComputeConpMatrix::deallocate() {
 }
 
 /* ---------------------------------------------------------------------- */
-
-void ComputeConpMatrix::write_matrix(FILE *f, double **matrix) {
-  fprintf(f, "# atoms\n");
-  for (bigint i = 0; i < ngroup; i++) fprintf(f, "%d ", mat2tag[i]);
-  fprintf(f, "\n");
-
-  fprintf(f, "# matrix\n");
-  for (bigint i = 0; i < ngroup; i++) {
-    for (bigint j = 0; j < ngroup; j++) {
-      fprintf(f, "%E ", matrix[i][j]);
-    }
-    fprintf(f, "\n");
-  }
-}
-
-/* ---------------------------------------------------------------------- */
-
-void ComputeConpMatrix::write_matrix(FILE *f, double *matrix) {
-  fprintf(f, "# atoms\n");
-  for (bigint i = 0; i < ngroup; i++) fprintf(f, "%d ", mat2tag[i]);
-  fprintf(f, "\n");
-
-  fprintf(f, "# matrix\n");
-  for (bigint i = 0; i < ngroup; i++) {
-    for (bigint j = 0; j < ngroup; j++) {
-      fprintf(f, "%E ", matrix[i * ngroup + j]);
-    }
-    fprintf(f, "\n");
-  }
-}

--- a/src/USER-CONP/compute_conp_matrix.cpp
+++ b/src/USER-CONP/compute_conp_matrix.cpp
@@ -91,11 +91,10 @@ ComputeConpMatrix::ComputeConpMatrix(LAMMPS *lmp, int narg, char **arg)
 
   // TODO recalculate coulomb matrix every recalc_every
 
-  recalc_every = utils::inumeric(FLERR, arg[3], false, lmp);
   // TODO infer from pair_style!
-  eta = utils::numeric(FLERR, arg[4], false, lmp);
+  eta = utils::numeric(FLERR, arg[3], false, lmp);
 
-  int iarg = 5;
+  int iarg = 4;
   while (iarg < narg) {
     if (strcmp(arg[iarg], "pair") == 0) {
       if (iarg + 2 > narg)
@@ -244,8 +243,7 @@ void ComputeConpMatrix::init() {
 /* ---------------------------------------------------------------------- */
 
 void ComputeConpMatrix::setup() {
-  igroupnum = group->count(igroup);
-  ngroup = igroupnum;
+  ngroup = group->count(igroup);
 
   // TODO could be useful to assign homogenously all atoms in both groups to
   // all procs for calculating matrix to distribute evenly the workload
@@ -487,14 +485,14 @@ void ComputeConpMatrix::matrix_assignment() {
     }
   }
 
-  memory->create(itaglist, igroupnum, "coul/matrix:itaglist");
+  memory->create(itaglist, ngroup, "coul/matrix:itaglist");
 
   MPI_Allgatherv(itaglist_local, igroupnum_local, MPI_LMP_TAGINT, itaglist,
                  igroupnum_list, idispls, MPI_LMP_TAGINT, world);
 
   // sort individual group taglists, first igroup than jgroup
 
-  std::sort(itaglist, itaglist + igroupnum);
+  std::sort(itaglist, itaglist + ngroup);
 
   // if local+ghost matrix assignment already created, recreate
 
@@ -510,7 +508,7 @@ void ComputeConpMatrix::matrix_assignment() {
 
   // store which tag represents value in matrix
 
-  for (bigint i = 0; i < igroupnum; i++) mat2tag[i] = itaglist[i];
+  for (bigint i = 0; i < ngroup; i++) mat2tag[i] = itaglist[i];
 
   // create global matrix indices for local+ghost atoms
 

--- a/src/USER-CONP/compute_conp_matrix.h
+++ b/src/USER-CONP/compute_conp_matrix.h
@@ -58,8 +58,6 @@ class ComputeConpMatrix : public Compute {
   void matrix_assignment();
   void pair_contribution();
   void self_contribution();
-  void write_matrix(FILE *, double **);
-  void write_matrix(FILE *, double *);
   void allocate();
   void deallocate();
   double calc_erfc(double);

--- a/src/USER-CONP/compute_conp_matrix.h
+++ b/src/USER-CONP/compute_conp_matrix.h
@@ -37,11 +37,10 @@ class ComputeConpMatrix : public Compute {
   tagint *mat2tag;  // stores tag of matrix position
 
  private:
-  char *group2;
-  int jgroup, jgroupbit, othergroupbit;
-  bigint jgroupnum, igroupnum, ngroup;
+  int othergroupbit;
+  bigint igroupnum, ngroup;
   int recalc_every;
-  double **cutsq, **gradQ_V, *gradQ_V_inv;
+  double **cutsq, **gradQ_V;
   double g_ewald, eta;
   int pairflag, kspaceflag, boundaryflag, selfflag;
   bool assigned;
@@ -59,8 +58,8 @@ class ComputeConpMatrix : public Compute {
   void matrix_assignment();
   void pair_contribution();
   void self_contribution();
-  void write_matrix(FILE*, double **);
-  void write_matrix(FILE*, double *);
+  void write_matrix(FILE *, double **);
+  void write_matrix(FILE *, double *);
   void allocate();
   void deallocate();
   double calc_erfc(double);

--- a/src/USER-CONP/compute_conp_matrix.h
+++ b/src/USER-CONP/compute_conp_matrix.h
@@ -40,7 +40,7 @@ class ComputeConpMatrix : public Compute {
   int othergroupbit;
   bigint ngroup;
   int recalc_every;
-  double **cutsq, **gradQ_V;
+  double **cutsq;
   double g_ewald, eta;
   int pairflag, kspaceflag, boundaryflag, selfflag;
   bool assigned;
@@ -54,7 +54,6 @@ class ComputeConpMatrix : public Compute {
 
   long filepos;
 
-  void invert();
   void matrix_assignment();
   void pair_contribution();
   void self_contribution();

--- a/src/USER-CONP/compute_conp_matrix.h
+++ b/src/USER-CONP/compute_conp_matrix.h
@@ -38,7 +38,7 @@ class ComputeConpMatrix : public Compute {
 
  private:
   int othergroupbit;
-  bigint igroupnum, ngroup;
+  bigint ngroup;
   int recalc_every;
   double **cutsq, **gradQ_V;
   double g_ewald, eta;

--- a/src/USER-CONP/compute_conp_vector.cpp
+++ b/src/USER-CONP/compute_conp_vector.cpp
@@ -62,11 +62,10 @@ ComputeConpVector::ComputeConpVector(LAMMPS *lmp, int narg, char **arg)
 
   // TODO recalculate coulomb vector every recalc_every
 
-  recalc_every = utils::inumeric(FLERR, arg[3], false, lmp);
   eta =
-      utils::numeric(FLERR, arg[4], false, lmp);  // TODO infer from pair_style!
+      utils::numeric(FLERR, arg[3], false, lmp);  // TODO infer from pair_style!
 
-  int iarg = 5;
+  int iarg = 4;
   while (iarg < narg) {
     if (strcmp(arg[iarg], "pair") == 0) {
       if (iarg + 2 > narg)
@@ -224,7 +223,7 @@ void ComputeConpVector::pair_contribution() {
   int *mask = atom->mask;
   neighbor->build_one(list);
   int const nlocal = atom->nlocal;
-  int const nall = atom->nghost + nlocal;
+  int const nmax = atom->nmax;
   int const inum = list->inum;
   int *ilist = list->ilist;
   int *numneigh = list->numneigh;
@@ -263,7 +262,7 @@ void ComputeConpVector::pair_contribution() {
       }
       if (i_in_electrode && (i < nlocal)) {
         vector[mpos[i]] += aij * q[j];
-      } else if (j_in_electrode && (j < nall)) {
+      } else if (j_in_electrode && (j < nmax)) {
         vector[mpos[j]] += aij * q[i];
       }
     }
@@ -304,14 +303,14 @@ void ComputeConpVector::create_taglist() {
 /* ---------------------------------------------------------------------- */
 
 void ComputeConpVector::update_mpos() {
-  int const nall = atom->nlocal + atom->nghost;
+  int const nmax = atom->nmax;
   int *tag = atom->tag;
   if (assigned) delete[] mpos;
-  mpos = new bigint[nall];
+  mpos = new bigint[nmax];
   assigned = true;
-  for (int i = 0; i < nall; i++) mpos[i] = -1;
+  for (int i = 0; i < nmax; i++) mpos[i] = -1;
   for (bigint ii = 0; ii < ngroup; ii++) {
-    for (int i = 0; i < nall; i++) {
+    for (int i = 0; i < nmax; i++) {
       if (taglist[ii] == tag[i]) {
         mpos[i] = ii;
       }

--- a/src/USER-CONP/compute_conp_vector.cpp
+++ b/src/USER-CONP/compute_conp_vector.cpp
@@ -60,8 +60,6 @@ ComputeConpVector::ComputeConpVector(LAMMPS *lmp, int narg, char **arg)
 
   assigned = false;
 
-  // TODO recalculate coulomb vector every recalc_every
-
   eta =
       utils::numeric(FLERR, arg[3], false, lmp);  // TODO infer from pair_style!
 
@@ -297,6 +295,7 @@ void ComputeConpVector::create_taglist() {
   MPI_Allgatherv(&taglist_local.front(), igroupnum_local, MPI_LMP_TAGINT,
                  &taglist.front(), &igroupnum_list.front(), &idispls.front(),
                  MPI_LMP_TAGINT, world);
+  // must be sorted for compatibility with fix_charge_update
   std::sort(taglist.begin(), taglist.end());
 }
 

--- a/src/USER-CONP/compute_conp_vector.h
+++ b/src/USER-CONP/compute_conp_vector.h
@@ -53,10 +53,8 @@ class ComputeConpVector : public Compute {
 
   void create_taglist();
   void update_mpos();
-  std::vector<tagint> mat2tag();
 
   void pair_contribution();
-  void write_vector(FILE *, double *, std::vector<tagint>);
   double calc_erfc(double);
 };
 

--- a/src/USER-CONP/compute_conp_vector.h
+++ b/src/USER-CONP/compute_conp_vector.h
@@ -37,9 +37,8 @@ class ComputeConpVector : public Compute {
   tagint *mat2tag;  // stores tag of matrix position
 
  private:
-  char *group2;
-  int jgroup, jgroupbit, othergroupbit;
-  bigint jgroupnum, igroupnum, ngroup;
+  int othergroupbit;
+  bigint igroupnum, ngroup;
   int recalc_every;
   double **cutsq;
   double g_ewald, eta;

--- a/src/USER-CONP/compute_conp_vector.h
+++ b/src/USER-CONP/compute_conp_vector.h
@@ -33,19 +33,16 @@ class ComputeConpVector : public Compute {
   void init_list(int, class NeighList *);
   void compute_vector();
 
- protected:
-  tagint *mat2tag;  // stores tag of matrix position
-
  private:
-  int othergroupbit;
-  bigint igroupnum, ngroup;
+  bigint ngroup;
   int recalc_every;
   double **cutsq;
   double g_ewald, eta;
   int pairflag, kspaceflag, boundaryflag;
-  bool assigned;
   int overwrite, gaussians;
-  bigint *mpos;  // locally stored matrix index of each local+ghost atom
+  std::vector<int> taglist;
+  bigint *mpos;
+  bool assigned;
   class Pair *pair;
   class NeighList *list;
   class KSpace *kspace;
@@ -54,12 +51,12 @@ class ComputeConpVector : public Compute {
 
   long filepos;
 
-  void matrix_assignment();
+  void create_taglist();
+  void update_mpos();
+  std::vector<tagint> mat2tag();
+
   void pair_contribution();
-  void pair_contribution_corr();
-  void write_vector(FILE *, double *);
-  void allocate();
-  void deallocate();
+  void write_vector(FILE *, double *, std::vector<tagint>);
   double calc_erfc(double);
 };
 

--- a/src/USER-CONP/ewald_conp.cpp
+++ b/src/USER-CONP/ewald_conp.cpp
@@ -21,7 +21,6 @@
 #include "ewald_conp.h"
 
 #include <cmath>
-#include <iostream>
 
 #include "atom.h"
 #include "comm.h"
@@ -35,7 +34,6 @@
 
 using namespace LAMMPS_NS;
 using namespace MathConst;
-using namespace std;
 
 #define SMALL 0.00001
 
@@ -1833,7 +1831,6 @@ void EwaldConp::compute_vector(bigint *imat, double *vector) {
       memory->create3d_offset(sn, -kmax, kmax, 3, nmax, "ewald/conp:sn");
       kmax_created = kmax;
     }
-    if (comm->me == 0) cout << "Updating cs and sn" << endl;
     eikr_step = update->ntimestep;
     if (triclinic == 0)
       eik_dot_r();

--- a/src/USER-CONP/ewald_conp.h
+++ b/src/USER-CONP/ewald_conp.h
@@ -85,6 +85,9 @@ class EwaldConp : public KSpace {
   void wirecorr_groups(int, int, int);
   void allocate_groups();
   void deallocate_groups();
+ 
+ private:
+  int eikr_step;
 };
 
 }  // namespace LAMMPS_NS

--- a/src/USER-CONP/fix_charge_update.cpp
+++ b/src/USER-CONP/fix_charge_update.cpp
@@ -267,11 +267,11 @@ void FixChargeUpdate::create_taglist() {
 /* ---------------------------------------------------------------------- */
 
 std::vector<int> FixChargeUpdate::local_to_matrix() {
-  int const nall = atom->nlocal + atom->nghost;
+  int const nmax = atom->nmax;
   int *tag = atom->tag;
-  std::vector<int> mpos(nall, -1);
+  std::vector<int> mpos(nmax, -1);
   for (bigint ii = 0; ii < ngroup; ii++) {
-    for (int i = 0; i < nall; i++) {
+    for (int i = 0; i < nmax; i++) {
       if (taglist[ii] == tag[i]) {
         mpos[i] = ii;
       }
@@ -284,11 +284,11 @@ std::vector<int> FixChargeUpdate::local_to_matrix() {
 
 void FixChargeUpdate::pre_force(int) {
   std::vector<int> mpos = local_to_matrix();
-  int const nall = atom->nlocal + atom->nghost;
+  int const nmax = atom->nmax;
   double **a = read_matrix ? matrix_from_file : array_compute->array;
   vector_compute->compute_vector();
   double *b = vector_compute->vector;
-  for (int i = 0; i < nall; i++) {
+  for (int i = 0; i < nmax; i++) {
     int const pos = mpos[i];
     if (pos < 0) continue;
     double q_tmp = 0;

--- a/src/USER-CONP/fix_charge_update.cpp
+++ b/src/USER-CONP/fix_charge_update.cpp
@@ -1,0 +1,199 @@
+#include "fix_charge_update.h"
+
+#include <assert.h>
+
+
+#include "atom.h"
+#include "comm.h"
+#include "compute.h"
+#include "error.h"
+#include "force.h"
+#include "group.h"
+#include "memory.h"
+#include "modify.h"
+
+using namespace LAMMPS_NS;
+using namespace FixConst;
+
+//     0        1   2             3
+// fix fxupdate all charge_update group1 pot1 group2 pot2 c_matrix c_vector
+FixChargeUpdate::FixChargeUpdate(LAMMPS *lmp, int narg, char **arg)
+    : Fix(lmp, narg, arg) {
+  array_compute = vector_compute = nullptr;
+  assigned = false;
+
+  int iarg = 3;
+  for (int i = 0; i < number_groups; i++) {
+    int id = group->find(arg[iarg++]);
+    double pot = utils::numeric(FLERR, arg[iarg++], false,
+                                lmp);  //* force->qe2f; // V -> kcal / (mol e)
+    if (id < 0) error->all(FLERR, "Group does not exist");
+    groups.push_back(id);
+    group_bits.push_back(group->bitmask[id]);
+    group_pots.push_back(pot);
+  }
+  assert(groups.size == group_bits.size);
+  assert(groups.size == group_pots.size);
+
+  std::vector<std::string> compute_ids;
+  while (iarg < narg) {
+    if ((strncmp(arg[iarg], "c_", 2) == 0)) {
+      compute_ids.push_back(&arg[iarg][2]);
+    }
+    iarg++;
+  }
+
+  for (std::string id : compute_ids) {
+    int i = modify->find_compute(id);
+    if (i < 0)
+      error->all(FLERR, "Compute ID for fix charge_update does not exist");
+    Compute *c = modify->compute[i];
+    if (c->array_flag) {
+      if (array_compute == nullptr) {
+        array_compute = c;
+      } else {
+        error->all(FLERR, "Fix charge_update can only use one array compute");
+      }
+    }
+    if (c->vector_flag) {
+      if (vector_compute == nullptr) {
+        vector_compute = c;
+      } else {
+        error->all(FLERR, "Fix charge_update can only use one vector compute");
+      }
+    }
+  }
+  // error checks
+  if (array_compute == nullptr)
+    error->all(FLERR, "Fix charge_update needs one array compute");
+  if (vector_compute == nullptr)
+    error->all(FLERR, "Fix charge_update needs one vector compute");
+  for (Compute *c : {array_compute, vector_compute}) {
+    if (igroup != c->igroup) {
+      error->all(
+          FLERR,
+          "Group of fix charge update does not match group of its compute");
+    }
+  }
+  // TODO more checks for computes
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixChargeUpdate::init() {
+  int const nlocal = atom->nlocal;
+  int *mask = atom->mask;
+  ngroup = group->count(igroup);
+  int sum = 0;
+  for (int i : groups) {
+    sum += group->count(i);
+  }
+  if (sum != ngroup) {
+    error->all(FLERR,
+               "Count of igroup not equal to sum of counts of other groups");
+  }
+  for (int i = 0; i < nlocal; i++) {
+    int m = mask[i];
+    if (m & groupbit) {
+      int matches = 0;
+      for (int bit : group_bits)
+        if (m & bit) matches++;
+      if (matches != 1) {
+        error->all(
+            FLERR,
+            "All atoms in igroup must occur exactly once in other groups");
+      }
+    }
+  }
+
+  create_taglist();
+  std::vector<int> mpos = local_to_matrix();
+
+  double const evscale = 0.069447; // TODO do units properly
+  pots = new double[ngroup]();
+  for (int i = 0; i < nlocal; i++) {
+    for (int g = 0; g < number_groups; g++) {
+      if (mask[i] & group_bits[g]) pots[mpos[i]] = group_pots[g] * evscale;
+    }
+  }
+  MPI_Allreduce(MPI_IN_PLACE, pots, ngroup, MPI_DOUBLE, MPI_SUM, world);
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixChargeUpdate::create_taglist() {
+  // assign a tag to each matrix index
+
+  int *mask = atom->mask;
+  int const nlocal = atom->nlocal;
+  int const nprocs = comm->nprocs;
+  tagint *tag = atom->tag;
+
+  std::vector<int> taglist_local;
+  for (int i = 0; i < nlocal; i++) {
+    if (mask[i] & groupbit) taglist_local.push_back(tag[i]);
+  }
+  int igroupnum_local = taglist_local.size();
+
+  std::vector<int> idispls(nprocs);
+  std::vector<int> igroupnum_list(nprocs);
+  MPI_Allgather(&igroupnum_local, 1, MPI_INT, &igroupnum_list.front(), 1,
+                MPI_INT, world);
+  idispls[0] = 0;
+  for (int i = 1; i < nprocs; i++) {
+    idispls[i] = idispls[i - 1] + igroupnum_list[i - 1];
+  }
+
+  taglist = std::vector<int>(ngroup);
+  MPI_Allgatherv(&taglist_local.front(), igroupnum_local, MPI_LMP_TAGINT,
+                 &taglist.front(), &igroupnum_list.front(), &idispls.front(),
+                 MPI_LMP_TAGINT, world);
+  std::sort(taglist.begin(), taglist.end());
+}
+
+/* ---------------------------------------------------------------------- */
+
+std::vector<int> FixChargeUpdate::local_to_matrix() {
+  int const nlocal = atom->nlocal;
+  int *tag = atom->tag;
+  std::vector<int> mpos(nlocal, -1);
+  for (bigint ii = 0; ii < ngroup; ii++) {
+    for (int i = 0; i < nlocal; i++) {
+      if (taglist[ii] == tag[i]) {
+        mpos[i] = ii;
+      }
+    }
+  }
+  return mpos;
+}
+
+/* ---------------------------------------------------------------------- */
+
+void FixChargeUpdate::pre_force(int) {
+  std::vector<int> mpos = local_to_matrix();
+  int const nlocal = atom->nlocal;
+  double **a = array_compute->array;
+  vector_compute->compute_vector();
+  double *b = vector_compute->vector;
+  for (int i = 0; i < nlocal; i++) {
+    int const pos = mpos[i];
+    if (pos < 0) continue;
+    double q_tmp = 0;
+    for (int j = 0; j < ngroup; j++) {
+      q_tmp += a[pos][j] * (pots[j] - b[j]);
+    }
+    atom->q[i] = q_tmp;
+  }
+}
+
+/* ---------------------------------------------------------------------- */
+
+FixChargeUpdate::~FixChargeUpdate() { delete[] pots; }
+
+/* ---------------------------------------------------------------------- */
+
+int FixChargeUpdate::setmask() {
+  int mask = 0;
+  mask |= PRE_FORCE;
+  return mask;
+}

--- a/src/USER-CONP/fix_charge_update.cpp
+++ b/src/USER-CONP/fix_charge_update.cpp
@@ -1,6 +1,7 @@
 #include "fix_charge_update.h"
 
 #include <assert.h>
+#include <iostream>
 
 
 #include "atom.h"
@@ -14,6 +15,7 @@
 
 using namespace LAMMPS_NS;
 using namespace FixConst;
+using namespace std;
 
 //     0        1   2             3
 // fix fxupdate all charge_update group1 pot1 group2 pot2 c_matrix c_vector
@@ -170,6 +172,7 @@ std::vector<int> FixChargeUpdate::local_to_matrix() {
 /* ---------------------------------------------------------------------- */
 
 void FixChargeUpdate::pre_force(int) {
+  if (comm->me == 0) cout << "### PRE FORCE ###" << endl;
   std::vector<int> mpos = local_to_matrix();
   int const nlocal = atom->nlocal;
   double **a = array_compute->array;

--- a/src/USER-CONP/fix_charge_update.h
+++ b/src/USER-CONP/fix_charge_update.h
@@ -30,17 +30,17 @@ class FixChargeUpdate : public Fix {
   // void restart(char *);
 
  private:
-  FILE *f_ela, *f_vec, *f_cap;  // files for capacitance, eleastance and vector
-  std::string input_file_elas, input_file_cap;
+  FILE *f_inv, *f_vec, *f_mat;  // files for capacitance, eleastance and vector
+  std::string input_file_inv, input_file_mat;
   class Compute *array_compute, *vector_compute;
   static int const number_groups = 2;
   std::vector<int> groups, group_bits;
-  std::vector<double> group_pots;
-  std::vector<double> pots;
+  std::vector<double> group_psi;
+  std::vector<double> psi;
   std::vector<std::vector<double> > elastance;
   bigint ngroup;
   std::vector<tagint> taglist, taglist_bygroup, group_idx;
-  bool read_elas, read_cap;
+  bool read_inv, read_mat;
   void create_taglist();
   void invert(std::vector<std::vector<double> >);
   std::vector<int> local_to_matrix();

--- a/src/USER-CONP/fix_charge_update.h
+++ b/src/USER-CONP/fix_charge_update.h
@@ -19,6 +19,7 @@ class FixChargeUpdate : public Fix {
   int setmask();
   // void post_constructor();
   void init();
+  void setup(int);
   // void setup_pre_force(int);
   void pre_force(int);
   // void post_run();
@@ -29,16 +30,19 @@ class FixChargeUpdate : public Fix {
   // void restart(char *);
 
  private:
+  FILE *f_ela, *f_vec;  // files for capacitance, eleastance and vector
   class Compute *array_compute, *vector_compute;
   static int const number_groups = 2;
   std::vector<int> groups, group_bits;
   std::vector<double> group_pots;
   double *pots;
   int ngroup;
-  std::vector<int> taglist;
+  std::vector<tagint> taglist, taglist_bygroup, group_idx;
   bool assigned;
   void create_taglist();
   std::vector<int> local_to_matrix();
+  void write_2d_vector(FILE *, std::vector<tagint>,
+                       std::vector<std::vector<double> >);
 };
 
 }  // namespace LAMMPS_NS

--- a/src/USER-CONP/fix_charge_update.h
+++ b/src/USER-CONP/fix_charge_update.h
@@ -30,19 +30,21 @@ class FixChargeUpdate : public Fix {
   // void restart(char *);
 
  private:
-  FILE *f_ela, *f_vec;  // files for capacitance, eleastance and vector
+  FILE *f_ela, *f_vec, *f_in;  // files for capacitance, eleastance and vector
   class Compute *array_compute, *vector_compute;
   static int const number_groups = 2;
   std::vector<int> groups, group_bits;
   std::vector<double> group_pots;
   double *pots;
-  int ngroup;
+  double **matrix_from_file;
+  bigint ngroup;
   std::vector<tagint> taglist, taglist_bygroup, group_idx;
-  bool assigned;
+  bool read_matrix;
   void create_taglist();
   std::vector<int> local_to_matrix();
-  void write_2d_vector(FILE *, std::vector<tagint>,
-                       std::vector<std::vector<double> >);
+  void write_to_file(FILE *, std::vector<tagint>,
+                     std::vector<std::vector<double> >);
+  void read_from_file();
 };
 
 }  // namespace LAMMPS_NS

--- a/src/USER-CONP/fix_charge_update.h
+++ b/src/USER-CONP/fix_charge_update.h
@@ -30,22 +30,23 @@ class FixChargeUpdate : public Fix {
   // void restart(char *);
 
  private:
-  FILE *f_ela, *f_vec, *f_in;  // files for capacitance, eleastance and vector
+  FILE *f_ela, *f_vec, *f_cap;  // files for capacitance, eleastance and vector
+  std::string input_file_elas, input_file_cap;
   class Compute *array_compute, *vector_compute;
   static int const number_groups = 2;
   std::vector<int> groups, group_bits;
   std::vector<double> group_pots;
-  double *pots;
-  double **elastance;
+  std::vector<double> pots;
+  std::vector<std::vector<double> > elastance;
   bigint ngroup;
   std::vector<tagint> taglist, taglist_bygroup, group_idx;
-  bool read_matrix;
+  bool read_elas, read_cap;
   void create_taglist();
-  void invert(double **);
+  void invert(std::vector<std::vector<double> >);
   std::vector<int> local_to_matrix();
   void write_to_file(FILE *, std::vector<tagint>,
                      std::vector<std::vector<double> >);
-  void read_from_file();
+  std::vector<std::vector<double> > read_from_file(std::string input_file);
 };
 
 }  // namespace LAMMPS_NS

--- a/src/USER-CONP/fix_charge_update.h
+++ b/src/USER-CONP/fix_charge_update.h
@@ -1,0 +1,47 @@
+
+#ifdef FIX_CLASS
+
+FixStyle(charge_update, FixChargeUpdate)
+
+#else
+
+#ifndef LMP_FIX_CHARGE_UPDATE_H
+#define LMP_FIX_CHARGE_UPDATE_H
+
+#include "fix.h"
+
+namespace LAMMPS_NS {
+
+class FixChargeUpdate : public Fix {
+ public:
+  FixChargeUpdate(class LAMMPS *, int, char **);
+  ~FixChargeUpdate();
+  int setmask();
+  // void post_constructor();
+  void init();
+  // void setup_pre_force(int);
+  void pre_force(int);
+  // void post_run();
+  // void setup_pre_force_respa(int,int);
+  // void pre_force_respa(int,int,int);
+  // void set_arrays(int);
+  // void write_restart(FILE *);
+  // void restart(char *);
+
+ private:
+  class Compute *array_compute, *vector_compute;
+  static int const number_groups = 2;
+  std::vector<int> groups, group_bits;
+  std::vector<double> group_pots;
+  double *pots;
+  int ngroup;
+  std::vector<int> taglist;
+  bool assigned;
+  void create_taglist();
+  std::vector<int> local_to_matrix();
+};
+
+}  // namespace LAMMPS_NS
+
+#endif
+#endif

--- a/src/USER-CONP/fix_charge_update.h
+++ b/src/USER-CONP/fix_charge_update.h
@@ -36,11 +36,12 @@ class FixChargeUpdate : public Fix {
   std::vector<int> groups, group_bits;
   std::vector<double> group_pots;
   double *pots;
-  double **matrix_from_file;
+  double **elastance;
   bigint ngroup;
   std::vector<tagint> taglist, taglist_bygroup, group_idx;
   bool read_matrix;
   void create_taglist();
+  void invert(double **);
   std::vector<int> local_to_matrix();
   void write_to_file(FILE *, std::vector<tagint>,
                      std::vector<std::vector<double> >);


### PR DESCRIPTION
Fix charge_update is now responsible for managing the elastance matrix and the b vector.
Reading and writing of the matrix and vector is done in the fix.
For the writing, the entries are sorted by groups in all other cases the entries are sorted by tags only. This allows an easier communication with the computes.
The computes use only one group, comprising all electrode atoms, the fix gets a group for each electrode with the target potential.
Writing the uninverted capacitance matrix is no longer possible.
I hope you do not mind std::vector. It makes a lot of things shorter and safer.
A test is available in the 'charge-update' branch of the crash-test repo. 
Still not tested for a moving electrolyte.