### PR TITLE
Symm in charge_update for charge neutrality

### DIFF
--- a/src/USER-CONP/fix_charge_update.h
+++ b/src/USER-CONP/fix_charge_update.h
@@ -42,8 +42,10 @@ class FixChargeUpdate : public Fix {
   bigint ngroup;
   std::vector<tagint> taglist, taglist_bygroup, group_idx;
   bool read_inv, read_mat;
+  bool symm;  // symmetrize elastance for charge neutrality
   void create_taglist();
   void invert(std::vector<std::vector<double> >);
+  void symmetrize();
   std::vector<int> local_to_matrix();
   void write_to_file(FILE *, std::vector<tagint>,
                      std::vector<std::vector<double> >);


### PR DESCRIPTION
Symmetrization of the elastance matrix enforces charge neutrality of
the system.
Use the keyword 'symm on/off' in fix charge_update.
Default is off.
The elastance matrix is overwritten before it is written to file.
